### PR TITLE
Adding role ARN to outputs so it can be referenced externally

### DIFF
--- a/cluster/outputs.tf
+++ b/cluster/outputs.tf
@@ -19,3 +19,8 @@ output "kube_state_metrics_deployment" {
   value       = var.deploy_manifests ? "${local.namespace}/${kubernetes_deployment.kube_state_metrics[0].metadata[0].name}" : "Not managed by this module"
   description = "Kube-state-metrics deployment name"
 }
+
+output "role_arn" {
+  value       = aws_iam_role.doit_eks_lens_collector.arn
+  description = "EKS Lens Collector ARN that can be referenced if creating deployment independently"
+}

--- a/cluster/outputs.tf
+++ b/cluster/outputs.tf
@@ -21,6 +21,6 @@ output "kube_state_metrics_deployment" {
 }
 
 output "role_arn" {
-  value       = aws_iam_role.doit_eks_lens_collector.arn
+  value       = aws_iam_role.doit_eks_lens_collector[0].arn
   description = "EKS Lens Collector ARN that can be referenced if creating deployment independently"
 }


### PR DESCRIPTION
Due to a need to deploy the EKS lens manifests independently of this module I still need to get the role ARN so it can be referenced in the service account deployment.