### PR TITLE
Add support for pod tolerations

### DIFF
--- a/cluster/k8s.tf
+++ b/cluster/k8s.tf
@@ -226,6 +226,17 @@ resource "kubernetes_deployment" "kube_state_metrics" {
             }
           }
         }
+
+        dynamic "toleration" {
+          for_each = var.kube_state_tolerations
+          content {
+            key      = toleration.value.key
+            operator = toleration.value.operator
+            value    = toleration.value.value
+            effect   = toleration.value.effect
+          }
+        }
+
       }
     }
   }
@@ -537,6 +548,17 @@ resource "kubernetes_deployment" "collector" {
             }
           }
         }
+
+        dynamic "toleration" {
+          for_each = var.otel_tolerations
+          content {
+            key      = toleration.value.key
+            operator = toleration.value.operator
+            value    = toleration.value.value
+            effect   = toleration.value.effect
+          }
+        }
+
       }
     }
   }

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -72,3 +72,25 @@ variable "otel_resources" {
 
   default = {}
 }
+
+variable "kube_state_tolerations" {
+  type = list(object({
+    key      = optional(string)
+    operator = optional(string)
+    value    = optional(string)
+    effect   = optional(string)
+  }))
+
+  default = []
+}
+
+variable "otel_tolerations" {
+  type = list(object({
+    key      = optional(string)
+    operator = optional(string)
+    value    = optional(string)
+    effect   = optional(string)
+  }))
+
+  default = []
+}


### PR DESCRIPTION
This makes it possible to define a list of tolerations so that you can work with and around tainted nodes as outlined here https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/