### PR TITLE
Update modules with more input vars

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -54,6 +54,14 @@ module "<REGION>-<CLUSTER_NAME>" {
   providers = {
     kubernetes = kubernetes.<PROVIDER_ALIAS>
   }
+
+  # If you want to set explicitly the NodeSelector for the OpenTelemetry Collector or the kube-state-metrics deployment, you can do so by setting the `otel_node_selector` and `kube_state_node_selector` variables:
+  # otel_node_selector = {
+  #   purpose = high-availability-node
+  # }
+  # kube_state_node_selector = {
+  #   purpose = high-availability-node
+  # }
 }
 ```
 
@@ -69,6 +77,8 @@ module "<REGION>-<CLUSTER_NAME>" {
 | otel\_env | Environment variables to set for the OpenTelemetry Collector | `map(string)` | `{}` | no |
 | otel\_memory\_limiter | Configuration for the memory limiter processor | <pre>object({<br>    check_interval         = string<br>    limit_percentage       = number<br>    spike_limit_percentage = number<br>  })</pre> | <pre>{<br>  "check_interval": "1s",<br>  "limit_percentage": 70,<br>  "spike_limit_percentage": 30<br>}</pre> | no |
 | otel\_resources | Resources to set for the OpenTelemetry Collector container | <pre>object({<br>    requests = object({<br>      cpu    = optional(string)<br>      memory = optional(string)<br>    })<br>    limits = object({<br>      cpu    = optional(string)<br>      memory = optional(string)<br>    })<br>  })</pre> | <pre>{}</pre> | no |
+| kube\_state\_node\_selector | Node Selector for the kube-state-metrics deployment | `map(string)` | `{}` | no |
+| otel\_node\_selector | Node Selector for the otel OpenTelemetry Collector deployment | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/cluster/k8s.tf
+++ b/cluster/k8s.tf
@@ -237,6 +237,8 @@ resource "kubernetes_deployment" "kube_state_metrics" {
           }
         }
 
+        node_selector = try(var.kube_state_node_selector, null)
+
       }
     }
   }
@@ -558,6 +560,8 @@ resource "kubernetes_deployment" "collector" {
             effect   = toleration.value.effect
           }
         }
+
+        node_selector = try(var.otel_node_selector, null)
 
       }
     }

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -94,3 +94,13 @@ variable "otel_tolerations" {
 
   default = []
 }
+
+variable "otel_node_selector" {
+  type = map(string)
+  default = null
+}
+
+variable "kube_state_node_selector" {
+  type = map(string)
+  default = null
+}

--- a/region-base/README.md
+++ b/region-base/README.md
@@ -8,6 +8,11 @@ It needs to be created only _once_ per AWS account _and_ region.
 ```hcl
 module "<REGION_NAME>-base" {
   source = "git::https://github.com/doitintl/terraform-eks-lens.git//region-base"
+
+  # If you need to set specific tags on you S3 bucket, you can do so by setting the `s3_tags` variable:
+  # s3_tags = {
+  #   <key> = <value>
+  # }
 }
 ```
 
@@ -15,7 +20,7 @@ module "<REGION_NAME>-base" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-|  |  |  |  |  |
+| s3\_tags | Map of tags to assign to the bucket | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/region-base/main.tf
+++ b/region-base/main.tf
@@ -10,6 +10,8 @@ locals {
 resource "aws_s3_bucket" "doit_eks_lens" {
   bucket        = "doitintl-eks-metrics-${local.account_id}-${local.region}"
   force_destroy = true
+
+  tags = merge({}, var.s3_tags)
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "doit_eks_lens" {

--- a/region-base/variables.tf
+++ b/region-base/variables.tf
@@ -3,3 +3,9 @@ variable "permissions_boundary" {
   description = "If provided, all IAM roles will be created with this permissions boundary attached."
   default     = ""
 }
+
+variable "s3_tags" {
+  type = map(string)
+  description = "Tags to apply to the S3 bucket"
+  default = {}
+}


### PR DESCRIPTION
This PR adds the functionality to set:
- tags for the S3 bucket on region-base module
- node selector for the deployments on cluster module