### PR TITLE
Add Image Pull Secrets Variable

### DIFF
--- a/cluster/k8s.tf
+++ b/cluster/k8s.tf
@@ -177,6 +177,13 @@ resource "kubernetes_deployment" "kube_state_metrics" {
         service_account_name            = kubernetes_service_account.doit_kube_state_metrics[count.index].metadata[0].name
         automount_service_account_token = true
 
+        dynamic "image_pull_secrets" {
+          for_each = var.kube_image_pull_secrets
+          content {
+            name = image_pull_secrets.value
+          }
+        }
+
         container {
           name  = "kube-state-metrics"
           image = var.cluster.kube_state_image

--- a/cluster/k8s.tf
+++ b/cluster/k8s.tf
@@ -440,6 +440,13 @@ resource "kubernetes_deployment" "collector" {
         restart_policy       = "Always"
         service_account_name = kubernetes_service_account.doit_collector[count.index].metadata[0].name
 
+        dynamic "image_pull_secrets" {
+          for_each = var.kube_image_pull_secrets
+          content {
+            name = image_pull_secrets.value
+          }
+        }
+
         container {
           name  = "otelcol"
           image = var.cluster.otel_image

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -104,3 +104,8 @@ variable "kube_state_node_selector" {
   type = map(string)
   default = null
 }
+
+variable "kube_image_pull_secrets" {
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
On April 1, 2025 Docker Hub will be limiting unauthenticated pulls to 10 an hour. To get around this limit and avoid any service disruption, we want to pull from our own mirror registry. 

More information here: https://docs.docker.com/docker-hub/usage/

We can pass in a custom image including our registry, but we need to be able to pass the associated pull secret as well since our mirror registry is private.

This pull request adds a new variable `kube_image_pull_secrets` to the module that adds a `image_pull_secrets` block to both deployments for each passed secret.

---

If there is a more preferred way to implement the same or similar functionality, let me know open to feedback!😄 