### PR TITLE
fix: Add empty filter to aws_s3_bucket_lifecycle_configuration

### DIFF
--- a/region-base/main.tf
+++ b/region-base/main.tf
@@ -20,6 +20,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "doit_eks_lens" {
   rule {
     id = "ExpiredDocumentsRule"
 
+    filter {}
+
     expiration {
       days = 7
     }


### PR DESCRIPTION
## Testing
- `tflint` and `terraform validate` pass ✅ 
- using `terraform plan`, if I comment out the filter clause I can see the warning, if I comment it in the warning's not there anymore ✅ 
![image](https://github.com/user-attachments/assets/df457208-6ab3-40c2-bc09-dd7f68c85573)

![image](https://github.com/user-attachments/assets/e1ec8790-04a9-4e32-b12b-6bf6f63f7601)
