### PR TITLE
remove aws provider version constraint

### DIFF
--- a/cluster/versions.tf
+++ b/cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.3"
+      version = ">= 5.3"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/region-base/versions.tf
+++ b/region-base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.3"
+      version = ">= 5.3"
     }
 
   }


### PR DESCRIPTION
this is to allow use of this module alongside modules that require aws version 6, while keeping backwards compatibility